### PR TITLE
Feature/roc 1981 remove previous draft

### DIFF
--- a/src/main/common/draft/draftStoreClient.ts
+++ b/src/main/common/draft/draftStoreClient.ts
@@ -57,6 +57,14 @@ export default class DraftStoreClient<T> {
   }
 
   delete (userId: number): Promise<void> {
-    return request.delete(this.endpointURL, withAuthHeader(userId))
+    return request
+      .delete(this.endpointURL, withAuthHeader(userId))
+      .catch(err => {
+        if (err.statusCode === HttpStatus.NOT_FOUND) {
+          return null
+        } else {
+          throw err
+        }
+      })
   }
 }

--- a/src/main/features/claim/routes/start.ts
+++ b/src/main/features/claim/routes/start.ts
@@ -1,7 +1,19 @@
 import * as express from 'express'
 import { Paths } from 'claim/paths'
+import { ClaimDraftMiddleware } from 'claim/draft/claimDraftMiddleware'
 
 export default express.Router()
+
   .get(Paths.startPage.uri, (req: express.Request, res: express.Response) => {
     res.render(Paths.startPage.associatedView)
+  })
+
+  .post(Paths.startPage.uri, async (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> => {
+    try {
+      await ClaimDraftMiddleware.delete(res, next)
+      res.redirect(Paths.representativeNamePage.uri)
+    } catch (err) {
+      next(err)
+    }
+
   })

--- a/src/main/features/claim/views/start.njk
+++ b/src/main/features/claim/views/start.njk
@@ -3,47 +3,49 @@
 {% set title = t('Money claim') %}
 {% set heading = t('Issue civil court proceedings') %}
 
-{% from "form.njk" import submitButton %}
+{% from "form.njk" import linkButton, csrfProtection %}
 
 {% block content %}
 
-<h2 class="heading-medium">{{ t('Who this service is for') }}</h2>
+  <h2 class="heading-medium">{{ t('Who this service is for') }}</h2>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <p>{{ t('To use this service you must be') }}</p>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p>{{ t('To use this service you must be') }}</p>
 
-    <ul class="list list-bullet">
-      <li>{{ t('a legal representative') }}</li>
-      <li>{{ t('issuing a claim for an unfixed amount of money') }}</li>
-      <li>{{ t('serving the claim yourself') }}</li>
-    </ul>
-
-    <h2 class="heading-medium">{{ t('What this service does') }}</h2>
-
-    <p>{{ t('This service is an alternative to posting a completed N1 claim form - it allows you to:') }}</p>
-
-    <ul class="list list-bullet">
-      <li>{{ t('issue civil court proceedings in the County Court') }}</li>
-      <li>{{ t('calculate and pay the issue fee using Fee Account') }}</li>
-      <li>{{ t('download the sealed claim form to serve on the defendant yourself') }}</li>
-    </ul>
-
-    <p>{{ t('It normally takes 15 minutes to complete') }}<p>
-
-    <a class="button button-start" href="representative-name">{{ t('Start now') }}</a>
-
-    <h3 class="heading-small">{{ t('Before you start') }}</h3>
-
-    <p>{{ t("You'll need:") }}</p>
-    <div>
       <ul class="list list-bullet">
-        <li>{{ t('current addresses for all claimants and defendants') }}</li>
-        <li>{{ t('the address you want to serve the claim to') }}</li>
-        <li>{{ t("your client's permission to issue the claim") }}</li>
+        <li>{{ t('a legal representative') }}</li>
+        <li>{{ t('issuing a claim for an unfixed amount of money') }}</li>
+        <li>{{ t('serving the claim yourself') }}</li>
       </ul>
+
+      <h2 class="heading-medium">{{ t('What this service does') }}</h2>
+
+      <p>{{ t('This service is an alternative to posting a completed N1 claim form - it allows you to:') }}</p>
+
+      <ul class="list list-bullet">
+        <li>{{ t('issue civil court proceedings in the County Court') }}</li>
+        <li>{{ t('calculate and pay the issue fee using Fee Account') }}</li>
+        <li>{{ t('download the sealed claim form to serve on the defendant yourself') }}</li>
+      </ul>
+
+      <p>{{ t('It normally takes 15 minutes to complete') }}<p>
+      <form novalidate method="post">
+        {{ csrfProtection(csrf) }}
+        {{ linkButton('Start now', 'start', 'button button-start') }}
+      </form>
+
+      <h3 class="heading-small">{{ t('Before you start') }}</h3>
+
+      <p>{{ t("You'll need:") }}</p>
+      <div>
+        <ul class="list list-bullet">
+          <li>{{ t('current addresses for all claimants and defendants') }}</li>
+          <li>{{ t('the address you want to serve the claim to') }}</li>
+          <li>{{ t("your client's permission to issue the claim") }}</li>
+        </ul>
+      </div>
     </div>
   </div>
-</div>
 
 {% endblock %}

--- a/src/test/common/draft/draftMiddleware.ts
+++ b/src/test/common/draft/draftMiddleware.ts
@@ -1,0 +1,51 @@
+import * as express from 'express'
+import * as chai from 'chai'
+import * as spies from 'chai-spies'
+import * as sinon from 'sinon'
+import { mockRes } from 'sinon-express-mock'
+
+import { DraftMiddleware } from 'common/draft/draftMiddleware'
+
+import DraftStoreClient from 'common/draft/draftStoreClient'
+
+chai.use(spies)
+
+describe('Draft', () => {
+  describe('retrieve middleware', () => {
+    let spy
+
+    beforeEach(() => {
+      sinon.stub(DraftStoreClient.prototype, 'retrieve').callsFake(() => {
+        return Promise.resolve({})
+      })
+      spy = chai.spy.on(DraftStoreClient.prototype, 'retrieve')
+    })
+
+    it('should retrieve draft if the user is logged in', () => {
+      const res: express.Response = mockRes()
+      res.locals.isLoggedIn = true
+      res.locals.user = {
+        id: 123
+      }
+
+      new DraftMiddleware('default').retrieve(res, chai.spy())
+      chai.expect(spy).to.have.been.called()
+    })
+
+    it('should not retrieve draft if the user is not logged in', () => {
+      const res: express.Response = mockRes()
+      res.locals.isLoggedIn = false
+
+      new DraftMiddleware('default').retrieve(res, chai.spy())
+      chai.expect(spy).to.not.have.been.called()
+    })
+
+    it('should not retrieve draft if the isLoggedIn flag is not defined', () => {
+      const res: express.Response = mockRes()
+      res.locals.isLoggedIn = undefined
+
+      new DraftMiddleware('default').retrieve(res, chai.spy())
+      chai.expect(spy).to.not.have.been.called()
+    })
+  })
+})

--- a/src/test/common/draft/draftStoreClient.ts
+++ b/src/test/common/draft/draftStoreClient.ts
@@ -1,0 +1,90 @@
+/* tslint:disable:no-unused-expression */
+
+import * as chai from 'chai'
+import * as spies from 'chai-spies'
+import * as asPromised from 'chai-as-promised'
+import * as mock from 'mock-require'
+import * as HttpStatus from 'http-status-codes'
+
+import DraftStoreClient from 'common/draft/draftStoreClient'
+
+chai.use(spies)
+chai.use(asPromised)
+const expect = chai.expect
+
+function clientWithRequestMockedToThrow (statusCode: number): DraftStoreClient<any> {
+  mock('client/request', {
+    'default': {
+      get: (url, options) => {
+        return new Promise(() => {
+          throw {
+            statusCode: statusCode
+          }
+        })
+      }
+    }
+  })
+  mock.reRequire('../../../main/common/draft/draftStoreClient')
+  const constructor = require('../../../main/common/draft/draftStoreClient').default
+  return new constructor('default')
+}
+
+function clientWithRequestMockedToReturn (json: any): DraftStoreClient<any> {
+  mock('client/request', {
+    'default': {
+      get: (url, options) => Promise.resolve(json)
+    }
+  })
+  mock.reRequire('../../../main/common/draft/draftStoreClient')
+  const constructor = require('../../../main/common/draft/draftStoreClient').default
+  return new constructor('default')
+}
+
+describe('DraftStoreClient', () => {
+  describe('constructor', () => {
+    it('should fail when no draft type is provided', () => {
+      expect(() => new DraftStoreClient(undefined)).to.throw(Error, 'Draft type is required by the client')
+      expect(() => new DraftStoreClient(null)).to.be.throw(Error, 'Draft type is required by the client')
+      expect(() => new DraftStoreClient('')).to.be.throw(Error, 'Draft type is required by the client')
+    })
+  })
+
+  describe('retrieve', () => {
+    const deserializationFn = (value => value)
+
+    describe('when handling a request error', () => {
+      it('should return null for 404', async () => {
+        expect(await clientWithRequestMockedToThrow(HttpStatus.NOT_FOUND).retrieve(123, deserializationFn)).to.be.null
+      })
+
+      it('should throw/reject promise for 400', () => {
+        expect(clientWithRequestMockedToThrow(HttpStatus.BAD_REQUEST).retrieve(123, deserializationFn)).to.be.rejected
+      })
+
+      it('should throw/reject promise for 500', () => {
+        expect(clientWithRequestMockedToThrow(HttpStatus.INTERNAL_SERVER_ERROR).retrieve(123, deserializationFn)).to.be.rejected
+      })
+
+      it('should throw/reject promise for undefined status', () => {
+        expect(clientWithRequestMockedToThrow(undefined).retrieve(123, deserializationFn)).to.be.rejected
+      })
+    })
+
+    describe('when handling json returned from the backend', () => {
+      it('should deserialize object using provided deserialization function', async () => {
+        const spy = chai.spy(deserializationFn)
+
+        await clientWithRequestMockedToReturn({}).retrieve(123, spy)
+        chai.expect(spy).to.have.been.called
+      })
+
+      it('should reject upon receiving undefined', () => {
+        expect(clientWithRequestMockedToReturn(undefined).retrieve(123, deserializationFn)).to.be.rejected
+      })
+
+      it('should reject upon receiving null', () => {
+        expect(clientWithRequestMockedToReturn(null).retrieve(123, deserializationFn)).to.be.rejected
+      })
+    })
+  })
+})


### PR DESCRIPTION
**JIRA:**
https://tools.hmcts.net/jira/browse/ROC-1981

**Description:**
Given a legal representative is logged into the service, when the user selects the 'Start' button on the 'Start' page. then any existing draft claim for the same logged in legal representative in the draft claim store is deleted