### PR TITLE
Update cmc-common-frontend version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepush": "yarn test && yarn test:routes"
   },
   "dependencies": {
-    "@hmcts/cmc-common-frontend": "^1.4.7",
+    "@hmcts/cmc-common-frontend": "^1.4.9",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
     "@hmcts/nodejs-logging": "^1.1.1",
     "@types/config": "^0.0.32",

--- a/src/main/features/claim/views/submitted.njk
+++ b/src/main/features/claim/views/submitted.njk
@@ -12,8 +12,8 @@
         <div class="govuk-box-highlight">
           <h1 class="bold-large">{{ t('Your claim has been issued') }}</h1>
           <h2 class="bold-medium reference-number">{{ t('Claim number: %s', { postProcess: 'sprintf', sprintf: [claimNumber]}) }}</h2>
-          <div class="confirmation-detail">{{ t('Submitted: %s', { postProcess: 'sprintf', sprintf: [submittedDate | date]}) }}</div>
-          <div class="confirmation-detail">{{ t('Issued: %s', { postProcess: 'sprintf', sprintf: [issueDate | date]}) }}</div>
+          <div class="confirmation-detail">{{ t('Submitted %s', { postProcess: 'sprintf', sprintf: [submittedDate | date]}) }}</div>
+          <div class="confirmation-detail">{{ t('Issued %s', { postProcess: 'sprintf', sprintf: [issueDate | date]}) }}</div>
           <div class="confirmation-detail">{{ t('Fee paid: %s', { postProcess: 'sprintf', sprintf: [feePaid | numeral]}) }}</div>
         </div>
         <div class="form-group">{{ t("We've emailed confirmation to: ") }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/cmc-common-frontend@^1.4.7":
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/@hmcts/cmc-common-frontend/-/cmc-common-frontend-1.4.7.tgz#e805a1c25976053208412ea6ca8f4dba2ed14a48"
+"@hmcts/cmc-common-frontend@^1.4.9":
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/@hmcts/cmc-common-frontend/-/cmc-common-frontend-1.4.9.tgz#60bc3da11f46ce65aa80f301dda26cb85dbfb336"
 
 "@hmcts/nodejs-healthcheck@^1.4.3":
   version "1.4.3"


### PR DESCRIPTION
This PR uses the latest version(1.4.9) of cmc-common-frontend module in order to make questions bold in check your answers page. This is not a breaking change.  