### PR TITLE
ROC-2676: download sealed claim form on dashboard

### DIFF
--- a/src/main/features/dashboard/routes/claim-details.ts
+++ b/src/main/features/dashboard/routes/claim-details.ts
@@ -3,6 +3,7 @@ import { Paths as DashboardPaths } from 'dashboard/paths'
 import ClaimStoreClient from 'claims/claimStoreClient'
 import Claim from 'app/claims/models/claim'
 import ErrorHandling from 'common/errorHandling'
+import { Paths } from 'claim/paths'
 
 async function renderView (req: express.Request, res: express.Response): Promise<void> {
   const claim: Claim = await ClaimStoreClient.retrieveByClaimReference(res.locals.user.dashboardDraft.document.search.reference, res.locals.user.bearerToken)
@@ -13,7 +14,8 @@ async function renderView (req: express.Request, res: express.Response): Promise
     dateIssued: claim.issuedOn,
     claimants: claim.claimData.claimants,
     defendants: claim.claimData.defendants,
-    externalReference: claim.claimData.externalReferenceNumber
+    externalReference: claim.claimData.externalReferenceNumber,
+    sealedClaimPath: Paths.receiptReceiver.uri.replace(':externalId', claim.externalId)
   })
 }
 

--- a/src/main/features/dashboard/views/claim-details.njk
+++ b/src/main/features/dashboard/views/claim-details.njk
@@ -44,6 +44,7 @@
           <div class="form-label">{{ externalReference }}</div>
         </h3>
       {% endif %}
+      <p><a target="_blank" href="{{ sealedClaimPath }}" class="download">Download the sealed claim form</a> </p>
     </div>
   </div>
 {% endblock %}

--- a/src/main/features/dashboard/views/claim-details.njk
+++ b/src/main/features/dashboard/views/claim-details.njk
@@ -40,11 +40,11 @@
     </div>
     <div class="column-one-third {% if externalReference %}govuk-related-items{% endif %}">
       {% if externalReference %}
-        <h3 class="heading-medium">Your reference
+        <h3 class="heading-medium">{{ t('Your reference') }}
           <div class="form-label">{{ externalReference }}</div>
         </h3>
       {% endif %}
-      <p><a target="_blank" href="{{ sealedClaimPath }}" class="download">Download the sealed claim form</a> </p>
+      <p><a target="_blank" href="{{ sealedClaimPath }}" class="download">{{ t('Download the sealed claim form') }}</a> </p>
     </div>
   </div>
 {% endblock %}

--- a/src/main/public/stylesheets/application.scss
+++ b/src/main/public/stylesheets/application.scss
@@ -16,6 +16,7 @@ $path: '/legal/img/lib/';
 @import 'components/govuk-highlight-box-extension';
 @import 'components/layout';
 @import 'components/document-upload';
+@import 'components/document-download';
 
 .notice {
   margin-bottom: 1.5rem;

--- a/src/main/public/stylesheets/components/_document-download.scss
+++ b/src/main/public/stylesheets/components/_document-download.scss
@@ -1,4 +1,4 @@
-a.download {
+.download {
   background-image: url('/legal/img/lib/download-bullet.png');
   background-position-y: center;
   background-repeat: no-repeat;

--- a/src/main/public/stylesheets/components/_document-download.scss
+++ b/src/main/public/stylesheets/components/_document-download.scss
@@ -1,0 +1,7 @@
+a.download {
+  background-image: url('/legal/img/lib/download-bullet.png');
+  background-position-y: center;
+  background-repeat: no-repeat;
+  line-height: 32px;
+  padding-left: 30px;
+}


### PR DESCRIPTION
This PR adds the link to download sealed claim form on the dashboard. This is a no breaking change.
