### PR TITLE
Add new status value for new payment-api  image

### DIFF
--- a/src/main/app/pay/model/paymentResponse.ts
+++ b/src/main/app/pay/model/paymentResponse.ts
@@ -11,6 +11,6 @@ export class PaymentResponse {
   readonly status: string
 
   get isSuccess (): boolean {
-    return this.status === 'Success' || this.status === 'Initiated' || this.status === 'Pending'
+    return this.status === 'Pending'
   }
 }

--- a/src/main/app/pay/model/paymentResponse.ts
+++ b/src/main/app/pay/model/paymentResponse.ts
@@ -11,6 +11,6 @@ export class PaymentResponse {
   readonly status: string
 
   get isSuccess (): boolean {
-    return this.status === 'Success' || this.status === 'Initiated'
+    return this.status === 'Success' || this.status === 'Initiated' || this.status === 'Pending'
   }
 }

--- a/src/test/http-mocks/pay.ts
+++ b/src/test/http-mocks/pay.ts
@@ -7,7 +7,7 @@ const payPath = '/' + config.get<string>('pay.path')
 
 const paymentSuccessResponse: object = {
   reference: 'RC-1520-4276-0065-8715',
-  status: 'Success',
+  status: 'Pending',
   date_created: '18-02-2018 17:24:46.477Z'
 }
 


### PR DESCRIPTION
This PR fixes the `legal-frontend` to work with new docker image of `payment-api`.  
This should be merged along with PR # https://github.com/hmcts/cmc-integration-tests/pull/162