### PR TITLE
Org-name-bug-fix: Sending correct legalRep org name

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -51,7 +51,6 @@
     "service-name": "CMC",
     "currency": "GBP",
     "site-id": "AA00",
-    "organisation_name": "HMCTS",
     "description": "Money Claim issue fee"
   },
   "pdf-service": {

--- a/src/main/app/pay/payClient.ts
+++ b/src/main/app/pay/payClient.ts
@@ -14,7 +14,6 @@ const serviceName = config.get<string>('pay.service-name')
 const currency = config.get<string>('pay.currency')
 const siteId = config.get<string>('pay.site-id')
 const description = config.get<string>('pay.description')
-const organisationName = config.get<string>('pay.organisation_name')
 
 export class PayClient {
   constructor (public serviceAuthToken: ServiceAuthToken) {
@@ -25,8 +24,9 @@ export class PayClient {
                 pbaAccount: string,
                 caseReference: string,
                 customerReference: string,
+                organisationName: string,
                 fee: FeeResponse): Promise<PaymentResponse> {
-    const paymentReq: object = this.preparePaymentRequest(pbaAccount, caseReference, customerReference, fee)
+    const paymentReq: object = this.preparePaymentRequest(pbaAccount, caseReference, customerReference, organisationName, fee)
     const response: object = await request.post({
       uri: `${payUrl}/${payPath}`,
       body: paymentReq,
@@ -41,6 +41,7 @@ export class PayClient {
   private preparePaymentRequest (pbaAccount: string,
                                  caseReference: string,
                                  customerReference: string,
+                                 organisationName: string,
                                  fee: FeeResponse): object {
     if (StringUtils.isBlank(pbaAccount)) {
       throw new Error('Missing required parameter pbaAccount')

--- a/src/main/features/claim/routes/pay-by-account.ts
+++ b/src/main/features/claim/routes/pay-by-account.ts
@@ -126,6 +126,7 @@ export default express.Router()
             draft.document.feeAccount.reference,
             draft.document.externalId,
             draft.document.yourReference.reference,
+            draft.document.representative.organisationName.name,
             feeResponse
           )
 


### PR DESCRIPTION
Resolves #  Incorrect organisation name in PBA report

Notes:
* Unable to test it locally (click through) due to docker issues. Although all test passes

