### PR TITLE
ROC-3460: Use single instrumentation key for all services

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -62,7 +62,8 @@
   "feedback_legal_report_problem_survey": "FEEDBACK_REPORT_PROBLEM_URL",
   "feedback_legal_survey": "FEEDBACK_URL",
   "appInsights": {
-    "instrumentationKey": "APPINSIGHTS_INSTRUMENTATIONKEY"
+    "instrumentationKey": "APPINSIGHTS_INSTRUMENTATIONKEY",
+    "roleName": "APPINSIGHTS_ROLE_NAME"
   },
   "requestRetry": {
     "maxAttempts": "REQUEST_RETRY_MAX_ATTEMPTS"

--- a/config/default.json
+++ b/config/default.json
@@ -78,5 +78,8 @@
   },
   "documentManagement" : {
     "url": "http://localhost:8085"
+  },
+  "appInsights": {
+    "roleName": "legal-frontend"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,6 +39,7 @@ module "legal-frontend" {
   env = "${var.env}"
   ilbIp = "${var.ilbIp}"
   is_frontend  = true
+  appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
   subscription = "${var.subscription}"
   additional_host_name = "${var.external_host_name}"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -78,3 +78,8 @@ variable "client_id" {
 variable "external_host_name" {
   default = "moneyclaims-legal.sandbox.platform.hmcts.net"
 }
+
+variable "appinsights_instrumentation_key" {
+  description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
+  default = ""
+}

--- a/src/main/modules/app-insights/index.ts
+++ b/src/main/modules/app-insights/index.ts
@@ -1,10 +1,18 @@
 import * as config from 'config'
 import * as appInsights from 'applicationinsights'
 
+declare class AppInsightsConfiguration {
+  instrumentationKey: string
+  roleName: string
+}
+
 export class AppInsights {
   static enable () {
-    appInsights.setup(config.get<string>('appInsights.instrumentationKey'))
+    const appInsightsConfig = config.get<AppInsightsConfiguration>('appInsights')
+
+    appInsights.setup(appInsightsConfig.instrumentationKey)
       .setAutoCollectConsole(true, true)
-      .start()
+    appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = appInsightsConfig.roleName
+    appInsights.start()
   }
 }


### PR DESCRIPTION
JIRA link

https://tools.hmcts.net/jira/browse/ROC-3460

Change description

A change to start using a single App Insights insights instance which aggregates all services per environment.