### PR TITLE
Copy apple-touch-icon.png into root folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,12 @@ gulp.task('copy-files', () => {
     './node_modules/HTML_CodeSniffer/Auditor/**/*.{css,gif,png}'
   ])
   .pipe(gulp.dest(`${assetsDirectory}/stylesheets/lib/`))
+
+  gulp.src([
+    './node_modules/govuk_template_jinja/assets/images/apple-touch-icon.png'
+  ])
+
+  .pipe(gulp.dest(`${assetsDirectory}/`))
   gulp.src([
     './node_modules/govuk_frontend_toolkit/images/**/*',
     './node_modules/govuk_template_jinja/assets/images/*.*'


### PR DESCRIPTION
Copy file into root directory to stop 404s from appearing