### PR TITLE
Exclude the acb.yaml file from being ignored on acr build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@
 infrastructure
 kubernetes
 node_modules
+!acb.yaml
+!Dockerfile
 
 Jenkinsfile*
 README.md


### PR DESCRIPTION
Applying https://github.com/hmcts/cmc-citizen-frontend/pull/1448