### PR TITLE
Fix aseName to not use remote state

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -29,7 +29,7 @@ data "azurerm_key_vault_secret" "oauth_client_secret" {
 }
 
 locals {
-  aseName = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  aseName = "core-compute-${var.env}"
 
   local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
   local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.aseName}"

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -13,13 +13,3 @@ data "terraform_remote_state" "core_apps_infrastructure" {
   }
 }
 
-data "terraform_remote_state" "core_apps_compute" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-compute/${var.env}/terraform.tfstate"
-  }
-}


### PR DESCRIPTION
core-compute-aat remote state nuked by accident. This PR to fix permanently.