### PR TITLE
Fix nightly crossbrowser tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,8 +12,16 @@ properties([
 def product = "cmc"
 def component = "legal-frontend"
 
+// SAUCELABS config - configured on Jenkins (also IDAM_URL above used)
+env.IDAM_URL = 'https://idam-api.aat.platform.hmcts.net'
+env.SAUCELABS_BROWSER = 'chrome_win_latest'
+env.SAUCELABS_TUNNEL_IDENTIFIER = 'reformtunnel'
+env.SAUCELABS_USERNAME = 'username'
+env.SAUCELABS_ACCESS_KEY = 'privatekey'
+
 withNightlyPipeline("nodejs", product, component) {
   env.TEST_URL = params.URL_TO_TEST
+  env.LEGAL_APP_URL = params.URL_TO_TEST
 
   enableCrossBrowserTest()
   enableSecurityScan()

--- a/default.conf.js
+++ b/default.conf.js
@@ -11,7 +11,7 @@ exports.config = {
       host: process.env.WEB_DRIVER_HOST || 'localhost',
       port: process.env.WEB_DRIVER_PORT || '4444',
       browser: process.env.BROWSER || 'chrome',
-      url: process.env.CITIZEN_APP_URL || 'https://localhost:3000',
+      url: process.env.LEGAL_APP_URL || 'https://localhost:3000',
       waitForTimeout: 15000,
       desiredCapabilities: {
         proxy: new ProxySettings()

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sonar-scan": "sonar-scanner -Dsonar.projectKey='CMCLFE' -Dsonar.projectName='CMC :: Legal Frontend' -Dsonar.sources=src/main -Dsonar.tests=src/test -Dsonar.exclusions=src/main/public/**,src/main/features/certificateOfService/**,src/main/routes/info.ts,src/main/routes/health.ts,src/main/*.ts,src/main/modules/helmet/**,src/main/modules/nunjucks/**,src/main/modules/app-insights/** -Dsonar.typescript.lcov.reportPaths=coverage/lcov.info",
     "test:smoke": "./bin/run-smoke-tests.sh",
     "test:integration": "TS_NODE_TRANSPILE_ONLY=true ts-node --require tsconfig-paths/register ./node_modules/.bin/codeceptjs run --verbose --config default.conf.js --reporter mocha-multi",
-    "test:cross-browser": "TS_NODE_TRANSPILE_ONLY=true ts-node --require tsconfig-paths/register ./node_modules/.bin/codeceptjs run --verbose --config saucelabs.conf.js --reporter mocha-multi",
+    "test:crossbrowser": "TS_NODE_TRANSPILE_ONLY=true ts-node --require tsconfig-paths/register ./node_modules/.bin/codeceptjs run --verbose --config saucelabs.conf.js --reporter mocha-multi",
     "list-supported-browsers": "node -e 'Object.keys(require(\"@hmcts/cmc-supported-browsers\").supportedBrowsers).forEach(key => console.log(key))'",
     "precommit": "yarn lint",
     "prepush": "yarn test && yarn test:routes"

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -28,7 +28,7 @@ exports.config = {
   timeout: 10000,
   helpers: {
     WebDriverIO: {
-      url: process.env.CITIZEN_APP_URL || 'https://localhost:3000',
+      url: process.env.LEGAL_APP_URL || 'https://localhost:4000',
       browser: supportedBrowsers[browser].browserName,
       waitForTimeout: 60000,
       windowSize: '1600x900',


### PR DESCRIPTION
tools.hmcts.net/jira/browse/ROC-5531

Added missing env variables to Jenkinsfile.

Tested locally with:
`IDAM_URL=https://idam-api.aat.platform.hmcts.net LEGAL_APP_URL=https://cmc-legal-frontend-aat.service.core-compute-aat.internal SAUCELABS_BROWSER=chrome_win_latest SAUCELABS_TUNNEL_IDENTIFIER=reformtunnel SAUCELABS_USERNAME=markry-kainos SAUCELABS_ACCESS_KEY=*** yarn test:crossbrowser`
