### PR TITLE
Use IDAM PR Helm chart for whitelisting urls (and add liveness)

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -48,24 +48,6 @@ withPipeline("nodejs", product, component) {
     sh 'yarn setup'
   }
 
-  before('smoketest:aks') {
-    // workaround to fix SIDAM whitelisting for PR AKS URLs
-    try {
-      def encodedServiceName = 'Money%20Claims%20-%20Legal'
-      def aksUrlToWhitelist = env.TEST_URL + '/legal/receiver'
-      sh('curl -X PATCH https://idam-api.aat.platform.hmcts.net/testing-support/services/' + encodedServiceName +
-        ' -H \'Content-Type: application/json\'' +
-        ' -H \'cache-control: no-cache\'' +
-        ' -d \'[{' +
-        '"operation":"add",' +
-        '"field":"redirect_uri",' +
-        '"value":"' + aksUrlToWhitelist + '"' +
-        '}]\'')
-    } catch (err) {
-      notifyBuildEvent channel: notificationsChannel, color: 'warning', message: 'Failed to update SIDAM PR whitelisting'
-    }
-  }
-
   loadVaultSecrets(secrets)
   enableSlackNotifications(notificationsChannel)
   enableDockerBuild()

--- a/charts/cmc-legal-frontend/Chart.yaml
+++ b/charts/cmc-legal-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CMC Legal Frontend service
 name: cmc-legal-frontend
 home: https://github.com/hmcts/cmc-legal-rep-frontend
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: HMCTS CMC Dev Team
     email: cmc-developers@HMCTS.NET

--- a/charts/cmc-legal-frontend/requirements.yaml
+++ b/charts/cmc-legal-frontend/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: nodejs
-    version: 0.2.1
+    version: ~1.0.0
     repository: '@hmcts'
   - name: idam-pr
     version: ~1.0.0

--- a/charts/cmc-legal-frontend/requirements.yaml
+++ b/charts/cmc-legal-frontend/requirements.yaml
@@ -2,3 +2,8 @@ dependencies:
   - name: nodejs
     version: 0.2.1
     repository: '@hmcts'
+  - name: idam-pr
+    version: ~1.0.0
+    repository: '@hmcts'
+    tags:
+      - idam-pr

--- a/charts/cmc-legal-frontend/values.template.yaml
+++ b/charts/cmc-legal-frontend/values.template.yaml
@@ -1,3 +1,5 @@
+tags:
+  - idam-pr
 
 nodejs:
   image: ${IMAGE_NAME}
@@ -42,3 +44,8 @@ nodejs:
       - legal-draft-store-primary
       - legal-draft-store-secondary
       - legal-cookie-encryption-key
+      -
+idam-pr:
+  service:
+    name: Money Claims - Citizen
+    redirect_uri: https://${SERVICE_FQDN}/legal/receiver

--- a/charts/cmc-legal-frontend/values.template.yaml
+++ b/charts/cmc-legal-frontend/values.template.yaml
@@ -44,7 +44,7 @@ nodejs:
       - legal-draft-store-primary
       - legal-draft-store-secondary
       - legal-cookie-encryption-key
-      -
+
 idam-pr:
   service:
     name: Money Claims - Legal

--- a/charts/cmc-legal-frontend/values.template.yaml
+++ b/charts/cmc-legal-frontend/values.template.yaml
@@ -47,5 +47,5 @@ nodejs:
       -
 idam-pr:
   service:
-    name: Money Claims - Citizen
+    name: Money Claims - Legal
     redirect_uri: https://${SERVICE_FQDN}/legal/receiver

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hmcts/cmc-draft-store-middleware": "^2.0.0",
     "@hmcts/draft-store-client": "^1.2.1",
     "@hmcts/info-provider": "^1.0.0",
-    "@hmcts/nodejs-healthcheck": "^1.4.6",
+    "@hmcts/nodejs-healthcheck": "^1.5.1",
     "@hmcts/nodejs-logging": "^3.0.0",
     "@hmcts/requestretry": "^1.1.0",
     "@hmcts/cmc-validators": "^0.1.9",

--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -4,7 +4,6 @@ import * as healthcheck from '@hmcts/nodejs-healthcheck'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as toBoolean from 'to-boolean'
-import { FeatureToggles } from 'utils/featureToggles'
 
 /* tslint:disable:no-default-export */
 
@@ -36,9 +35,6 @@ function basicHealthCheck (serviceName) {
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'dockertests' || !process.env.NODE_ENV) {
     const sslDirectory = path.join(__dirname, '..', 'resources', 'localhost-ssl')
     options['ca'] = fs.readFileSync(path.join(sslDirectory, 'localhost-ca.crt'))
-  }
-  if (serviceName === 'pay' && FeatureToggles.isEnabled('mockPay')) {
-    return healthcheck.raw(() => { return healthcheck.up() })
   }
   return healthcheck.web(url(serviceName), options)
 }

--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -3,34 +3,37 @@ import * as config from 'config'
 import * as healthcheck from '@hmcts/nodejs-healthcheck'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as toBoolean from 'to-boolean'
+import { FeatureToggles } from 'utils/featureToggles'
 
-const checks = {
-  'claim-store': basicHealthCheck('claim-store'),
-  'draft-store': basicHealthCheck('draft-store'),
-  'fees': basicHealthCheck('fees'),
-  'pay': basicHealthCheck('pay'),
-  'idam-api': basicHealthCheck('idam.api'),
-  'idam-service-2-service-auth': basicHealthCheck('idam.service-2-service-auth')
+/* tslint:disable:no-default-export */
+
+let healthCheckRouter = express.Router()
+
+let healthCheckConfig = {
+  checks: {
+    'claimstore': basicHealthCheck('claim-store'),
+    'draft-store': basicHealthCheck('draft-store'),
+    'fees': basicHealthCheck('fees'),
+    'pay': basicHealthCheck('pay'),
+    'idam-service-2-service-auth': basicHealthCheck('idam.service-2-service-auth'),
+    'idam-api': basicHealthCheck('idam.api')
+  }
 }
 
-if (toBoolean(config.get('featureToggles.certificateOfService'))) {
-  checks['document-management-web'] = basicHealthCheck('documentManagement')
-}
-
-export default express.Router()
-  .get('/health', healthcheck.configure({
-    checks: checks
-  }))
+export default express.Router().use(healthCheckRouter)
+healthcheck.addTo(healthCheckRouter, healthCheckConfig)
 
 function basicHealthCheck (serviceName) {
   const options = {
     timeout: 5000,
     deadline: 15000
   }
-  if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV || process.env.NODE_ENV === 'dockertests') {
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'dockertests' || !process.env.NODE_ENV) {
     const sslDirectory = path.join(__dirname, '..', 'resources', 'localhost-ssl')
     options['ca'] = fs.readFileSync(path.join(sslDirectory, 'localhost-ca.crt'))
+  }
+  if (serviceName === 'pay' && FeatureToggles.isEnabled('mockPay')) {
+    return healthcheck.raw(() => { return healthcheck.up() })
   }
   return healthcheck.web(url(serviceName), options)
 }

--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -3,6 +3,7 @@ import * as config from 'config'
 import * as healthcheck from '@hmcts/nodejs-healthcheck'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as toBoolean from 'to-boolean'
 import { FeatureToggles } from 'utils/featureToggles'
 
 /* tslint:disable:no-default-export */
@@ -18,6 +19,10 @@ let healthCheckConfig = {
     'idam-service-2-service-auth': basicHealthCheck('idam.service-2-service-auth'),
     'idam-api': basicHealthCheck('idam.api')
   }
+}
+
+if (toBoolean(config.get('featureToggles.certificateOfService'))) {
+  healthCheckConfig.checks['document-management-web'] = basicHealthCheck('documentManagement')
 }
 
 export default express.Router().use(healthCheckRouter)

--- a/src/test/routes/health-checks.ts
+++ b/src/test/routes/health-checks.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai'
+import * as request from 'supertest'
+
+import 'test/routes/expectations'
+
+import { app } from 'main/app'
+
+describe('testing liveness', () => {
+  it('should return 200 OK', async () => {
+    await request(app)
+      .get('/health/liveness')
+      .expect(res => {
+        expect(res.status).equal(200)
+        expect(res.body.status).equal('UP')
+      })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,7 +122,7 @@
     lodash.mapvalues "^4.6.0"
     request-promise-native "^1.0.5"
 
-"@hmcts/nodejs-healthcheck@^1.4.6":
+"@hmcts/nodejs-healthcheck@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@hmcts/nodejs-healthcheck/-/nodejs-healthcheck-1.5.1.tgz#4d99f9e3041e11fcfacf0bec82eb8a2463fcea01"
   integrity sha512-DFaBhc42UU5X8uaaCmlHBk2Mrw12hNVWhWvd3zH3pN6ucCb/IgqxLMBOVXPClDzWwpKMlbKATN3EPz6rru47wg==


### PR DESCRIPTION
Testing a cleaner way to manage SIDAM whitelisting for PR URLs. This will add on install and remove on delete (merge).