### PR TITLE
Align the PR template with the citizen-frontend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,25 @@
-Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
+### JIRA link
 
-Notes:
-*
-*
-*
+
+### Change description
+
+
+### Work checklist
+
+- [ ] Unit tests added where applicable
+- [ ] Route tests added for new pages
+- [ ] New pages included in a11y tests
+- [ ] Task list and task completeness checks updated
+- [ ] Check and send page updated
+- [ ] Routes, page content and page flows of new features are toggled
+- [ ] UI changes look good on mobile
+- [ ] Required Google Analytics events are being sent
+
+### Developer self-QA run statement
+
+- [ ] I have clicked through the running application to see if all changes I made actually work.
+
+### Does this PR introduce a breaking change?
+
+- [ ] Yes
+- [ ] No


### PR DESCRIPTION
This is nothing like the template we're using for other OCMC projects:
---
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
